### PR TITLE
Prevent footnote spacing

### DIFF
--- a/static/v2.html
+++ b/static/v2.html
@@ -9,7 +9,7 @@
   <link href="https://www.juncture-digital.io/juncture/static/images/favicon.ico" rel="icon" type="image/png" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/juncture-digital/docs/css/index.css" rel="stylesheet">
-  <style data-id="footnote-numbering">#juncture section.footnote ol { list-style: decimal !important; padding-left: 1.5em !important; } #juncture section.footnote li { display: list-item !important; }</style>
+  <style data-id="footnote-numbering">#juncture section.footnote ol { list-style: decimal !important; padding-left: 1.5em !important; } #juncture section.footnote li { display: list-item !important; } #juncture section.footnote li:target::before, #juncture sup:target::before { content: none !important; display: none !important; height: 0 !important; margin: 0 !important; }</style>
 </head>
 <body style="opacity:0;">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-74LKHV7QM5" type="text/javascript"></script>


### PR DESCRIPTION
There's an odd issue with spacing in the footnotes after they've been clicked. This resolves it.